### PR TITLE
[efi] Attempt to connect our driver directly if ConnectController fails

### DIFF
--- a/src/interface/efi/efi_driver.c
+++ b/src/interface/efi/efi_driver.c
@@ -474,7 +474,16 @@ static int efi_driver_connect ( EFI_HANDLE device ) {
 		rc = -EEFI_CONNECT ( efirc );
 		DBGC ( device, "EFIDRV %s could not connect new drivers: "
 		       "%s\n", efi_handle_name ( device ), strerror ( rc ) );
-		return rc;
+		DBGC ( device, "EFIDRV %s connecting driver directly\n",
+		       efi_handle_name ( device ) );
+		if ( ( efirc = efi_driver_start ( &efi_driver_binding, device,
+						  NULL ) ) != 0 ) {
+			rc = -EEFI_CONNECT ( efirc );
+			DBGC ( device, "EFIDRV %s could not connect driver "
+			       "directly: %s\n", efi_handle_name ( device ),
+			       strerror ( rc ) );
+			return rc;
+		}
 	}
 	DBGC2 ( device, "EFIDRV %s after connecting:\n",
 		efi_handle_name ( device ) );


### PR DESCRIPTION
Some platforms (observed with an AMI BIOS on an Apollo Lake system)
will spuriously fail the call to ConnectController() when the UEFI
network stack is disabled.  This appears to be a BIOS bug that also
affects attempts to connect any non-iPXE driver to the NIC controller
handle via the UEFI shell "connect" utility.

Work around this BIOS bug by falling back to calling our
efi_driver_start() directly if the call to ConnectController() fails.
This bypasses any BIOS policy in terms of deciding which driver to
connect but still cooperates with the UEFI driver model in terms of
handle ownership, since the use of EFI_OPEN_PROTOCOL_BY_DRIVER ensures
that the BIOS is aware of our ownership claim.

Signed-off-by: Michael Brown <mcb30@ipxe.org>