### PR TITLE
[tls] Allow a minimum TLS protocol version to be specified

### DIFF
--- a/src/config/crypto.h
+++ b/src/config/crypto.h
@@ -9,6 +9,9 @@
 
 FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
 
+/** Minimum TLS version */
+#define TLS_VERSION_MIN TLS_VERSION_TLS_1_0
+
 /** RSA public-key algorithm */
 #define CRYPTO_PUBKEY_RSA
 


### PR DESCRIPTION
The supported ciphers and digest algorithms may already be specified
via config/crypto.h.  Extend this to allow a minimum TLS protocol
version to be specified.

Signed-off-by: Michael Brown <mcb30@ipxe.org>